### PR TITLE
Cross-platform file path to URI translation

### DIFF
--- a/src/main/java/org/xbib/elasticsearch/module/deploy/DeployService.java
+++ b/src/main/java/org/xbib/elasticsearch/module/deploy/DeployService.java
@@ -274,7 +274,7 @@ public class DeployService extends AbstractLifecycleComponent<DeployService> imp
                 jars.addAll(findJars(f.getAbsoluteFile()));
             } else {
                 if (f.getName().endsWith(".jar")) {
-                    jars.add(URI.create("file:" + f.getAbsolutePath()));
+                    jars.add(f.toURI());
                 }
             }
         }


### PR DESCRIPTION
This fixes the "Illegal character in opaque part" exception I mentioned in https://github.com/jprante/elasticsearch-plugin-deploy/issues/2

On Windows, `getAbsolutePath()` returns something like `c:\somepath\somefile.jar` which of course makes an illegal file URI.
